### PR TITLE
Log moisture sensor data in loop

### DIFF
--- a/main/app_main.c
+++ b/main/app_main.c
@@ -13,6 +13,8 @@
 #include "mqtt_client.h"
 #include "mqtt_credentials.h"
 #include "driver/adc.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static int read_adc_gpio0(void)
 {
@@ -106,4 +108,10 @@ void app_main(void)
     ESP_ERROR_CHECK(example_connect());
 
     mqtt_app_start();
+
+    while (1) {
+        int moisture = read_adc_gpio0();
+        ESP_LOGI("Dry value", "%d", moisture);
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
 }


### PR DESCRIPTION
## Summary
- Continuously poll the moisture sensor via ADC and log the "Dry value" each second
- Include FreeRTOS headers to support task delays

## Testing
- `idf.py build` (fails: command not found)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'paho')

------
https://chatgpt.com/codex/tasks/task_e_68aaa7c3aba8832cb3373e9398a1424b